### PR TITLE
fix: carousel not clickable and remove progress bar

### DIFF
--- a/app/modules/core/components/sections/Header.tsx
+++ b/app/modules/core/components/sections/Header.tsx
@@ -5,8 +5,6 @@ import { Link, NavLink, useLocation } from 'react-router';
 import { ColorModeToggle } from '~/modules/core/components/base/ColorModeToggle';
 import OptimizedImage from '~/modules/image-optimizer/components/OptimizedImage/OptimizedImage';
 
-import PageProgressBar from '../base/PageProgressBar';
-
 const STICKY_CLASSES_BASE = [
   'after:bg-white',
   'after:dark:bg-slate-900',
@@ -158,7 +156,6 @@ export function Header() {
   return (
     <>
       <div className="h-0 w-0" ref={observedRef} />
-      <PageProgressBar />
       <header
         className="container fixed left-0 right-0 top-0 z-20 mx-auto md:left-1/2 md:-translate-x-1/2 lg:max-w-5xl"
         ref={headerRef}

--- a/app/modules/introduction/pages/LandingPage.tsx
+++ b/app/modules/introduction/pages/LandingPage.tsx
@@ -20,7 +20,10 @@ export default function LandingPage({ posts, projects }: LandingPageProps) {
 
       <BrandHero className="py-8" />
 
-      <ProjectCarousel className="-mx-6 py-7 lg:py-16" projects={projects} />
+      <ProjectCarousel
+        className="z-10 -mx-6 py-7 lg:py-16"
+        projects={projects}
+      />
 
       <PostList className="py-12 lg:py-16" isTitleVisible posts={posts} />
 


### PR DESCRIPTION
# Changes

- fix project carousel not clickable due to covered by background ornament
- remove progress bar which making the page load feel slower